### PR TITLE
画像取得メソッド追加、画像を下層ページに表示

### DIFF
--- a/src/api/common.js
+++ b/src/api/common.js
@@ -1,0 +1,2 @@
+/** API URL */
+export const apiURL = 'https://dog.ceo/api'

--- a/src/api/fetchDogImage.js
+++ b/src/api/fetchDogImage.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+import { apiURL } from '~/api/common'
+
+export const fetchDogImage = (breed) =>
+  axios
+    .get(`${apiURL}/breed/${breed}/images`)
+    .then((response) => {
+      return response.data.message.map((link) => {
+        return {
+          url: link,
+          like: 0,
+        }
+      })
+    })
+    .catch((e) => ({ error: e }))

--- a/src/api/fetchDogName.js
+++ b/src/api/fetchDogName.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
+import { apiURL } from '~/api/common'
 
 export const fetchDogName = axios
-  .get('https://dog.ceo/api/breeds/list/all')
+  .get(`${apiURL}/breeds/list/all`)
   .then((response) => response.data.message)

--- a/src/pages/dogs/_breed/index.vue
+++ b/src/pages/dogs/_breed/index.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="container">
+    <div class="columns is-multiline">
+      <div v-for="(item, i) in dogimage" :key="i" class="column is-3">
+        <img :src="item.url" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { fetchDogImage } from '~/api/fetchDogImage'
+
+export default {
+  async asyncData({ store, params }) {
+    const dogimage = await fetchDogImage(params.breed)
+
+    await store.dispatch('register/setImages', dogimage)
+
+    return { dogimage }
+  },
+  computed: {
+    ...mapGetters('register', ['dogImageList']),
+  },
+}
+</script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="container">
-    <div>コンテンツが入るよ</div>
     <div class="columns is-multiline">
-      <div v-for="(item, i) in doglist" :key="i" class="column is-2">
-        <a class="button">{{ i }}</a>
+      <div v-for="(item, i) in dogNameList" :key="i" class="column is-2">
+        <!-- <a class="button">{{ i }}</a> -->
+        <nuxt-link :to="{ path: 'dogs/' + i }" class="button">
+          {{ i }}
+        </nuxt-link>
       </div>
     </div>
   </div>
@@ -16,14 +18,14 @@ import { fetchDogName } from '~/api/fetchDogName'
 export default {
   async asyncData({ store }) {
     const response = await fetchDogName
-    const dogsname = response
+    const dogname = response
 
-    await store.dispatch('register/setDogs', dogsname)
+    await store.dispatch('register/setDogs', dogname)
 
-    return { dogsname }
+    return { dogname }
   },
   computed: {
-    ...mapGetters('register', ['doglist']),
+    ...mapGetters('register', ['dogNameList']),
   },
 }
 </script>

--- a/src/store/register.js
+++ b/src/store/register.js
@@ -1,21 +1,31 @@
 export const state = () => ({
-  doglist: [],
+  dogNameList: [],
+  dogImageList: [],
 })
 
 export const getters = {
-  doglist(state) {
-    return state.doglist
+  dogNameList(state) {
+    return state.dogNameList
+  },
+  dogImageList(state) {
+    return state.dogImageList
   },
 }
 
 export const mutations = {
-  setDogs(state, dogsname) {
-    state.doglist = dogsname
+  setDogs(state, dogname) {
+    state.dogNameList = dogname
+  },
+  setImages(state, dogimage) {
+    state.dogImageList = dogimage
   },
 }
 
 export const actions = {
-  setDogs({ commit }, dogsname) {
-    commit('setDogs', dogsname)
+  setDogs({ commit }, dogname) {
+    commit('setDogs', dogname)
+  },
+  setImages({ commit }, dogimage) {
+    commit('setImages', dogimage)
   },
 }


### PR DESCRIPTION
## 概要
画像取得メソッド追加、画像を下層ページに表示

## 変更内容
 - 共通urlをcommon.jsに記述
 - 画像API取得
 - 下層ページ構築
 - 画像urlといいねをstoreに保存
 - 犬種ボタンに下層への遷移リンク追加

## 参考
https://www.luftgarden.jp/blog/86