### PR TITLE
詳細画面で画像を20件だけ表示させてページングを追加した

### DIFF
--- a/src/components/Modules/NavBar/index.vue
+++ b/src/components/Modules/NavBar/index.vue
@@ -2,7 +2,7 @@
   <nav class="navbar">
     <div class="container">
       <div class="navbar-brand">
-        <nuxt-link to="/breeds" class="navbar-item">いぬころ</nuxt-link>
+        <nuxt-link to="/breeds" class="navbar-item">わんこ</nuxt-link>
         <span class="navbar-burger burger" data-taeget="navbarMenu">
           <span></span>
           <span></span>

--- a/src/store/register.js
+++ b/src/store/register.js
@@ -1,6 +1,7 @@
 export const state = () => ({
   dogNameList: [],
   dogImageList: [],
+  pageCount: 1,
 })
 
 export const getters = {
@@ -9,6 +10,9 @@ export const getters = {
   },
   dogImageList(state) {
     return state.dogImageList
+  },
+  pageCount(state) {
+    return state.pageCount
   },
 }
 
@@ -19,6 +23,9 @@ export const mutations = {
   setImages(state, dogimage) {
     state.dogImageList = dogimage
   },
+  setPageCount(state, pagecount) {
+    state.pageCount = pagecount
+  },
 }
 
 export const actions = {
@@ -27,5 +34,8 @@ export const actions = {
   },
   setImages({ commit }, dogimage) {
     commit('setImages', dogimage)
+  },
+  setPageCount({ commit }, pagecount) {
+    commit('setPageCount', pagecount)
   },
 }


### PR DESCRIPTION
## 概要
詳細画面で画像を20件だけ表示させてページングを追加した

## 変更内容
 - わんころ -> わんこにタイトル変更
 - 件数を保持したいのでstore登録
 - ページングのスタイル追加（コピペ）
 - queryを使ってページングの機能追加

## 参考
ページング追加から
https://www.luftgarden.jp/blog/86/