### PR TITLE
詳細ページに犬種を表示させる

### DIFF
--- a/src/components/Modules/NavBar/index.vue
+++ b/src/components/Modules/NavBar/index.vue
@@ -2,7 +2,9 @@
   <nav class="navbar">
     <div class="container">
       <div class="navbar-brand">
-        <nuxt-link to="/breeds" class="navbar-item">わんこ</nuxt-link>
+        <nuxt-link to="/breeds" class="navbar-item title is-5">
+          わんこ
+        </nuxt-link>
         <span class="navbar-burger burger" data-taeget="navbarMenu">
           <span></span>
           <span></span>

--- a/src/pages/dogs/_breed/index.vue
+++ b/src/pages/dogs/_breed/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
+    <h2 class="title is-2">{{ dogTitle }}</h2>
     <div class="columns is-multiline">
-      <h2></h2>
       <div v-for="(item, i) in dogImageList" :key="i" class="column is-3">
         <img :src="item.url" />
         <span v-if="i < 3" class="tag is-danger">NEW</span>
@@ -58,6 +58,7 @@ export default {
   computed: {
     ...mapGetters('register', ['dogImageList']),
     ...mapGetters('register', ['pageCount']),
+    ...mapGetters('register', ['dogTitle']),
   },
 }
 </script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,10 +2,9 @@
   <div class="container">
     <div class="columns is-multiline">
       <div v-for="(item, i) in dogNameList" :key="i" class="column is-2">
-        <!-- <a class="button">{{ i }}</a> -->
-        <nuxt-link :to="{ path: 'dogs/' + i }" class="button">
+        <button class="button" @click="submit(i)">
           {{ i }}
-        </nuxt-link>
+        </button>
       </div>
     </div>
   </div>
@@ -26,6 +25,12 @@ export default {
   },
   computed: {
     ...mapGetters('register', ['dogNameList']),
+  },
+  methods: {
+    submit(i) {
+      this.$router.push('/dogs/' + i)
+      this.$store.dispatch('register/setDogTitle', i)
+    },
   },
 }
 </script>

--- a/src/store/register.js
+++ b/src/store/register.js
@@ -2,6 +2,7 @@ export const state = () => ({
   dogNameList: [],
   dogImageList: [],
   pageCount: 1,
+  dogTitle: '',
 })
 
 export const getters = {
@@ -13,6 +14,9 @@ export const getters = {
   },
   pageCount(state) {
     return state.pageCount
+  },
+  dogTitle(state) {
+    return state.dogTitle
   },
 }
 
@@ -26,6 +30,9 @@ export const mutations = {
   setPageCount(state, pagecount) {
     state.pageCount = pagecount
   },
+  setDogTitle(state, dogtitle) {
+    state.dogTitle = dogtitle
+  },
 }
 
 export const actions = {
@@ -37,5 +44,8 @@ export const actions = {
   },
   setPageCount({ commit }, pagecount) {
     commit('setPageCount', pagecount)
+  },
+  setDogTitle({ commit }, dogtitle) {
+    commit('setDogTitle', dogtitle)
   },
 }


### PR DESCRIPTION
## 概要
表題を実現するためにstore登録など行った

## 変更内容
 - 犬種をstoreに登録する枠組みを作成
 - 犬種ボタンをクリックしたときに犬種名をstoreに保存、遷移
 - 詳細ページで犬種を表示
